### PR TITLE
Update to clojure 1.9.0-alpha16

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,10 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :plugins [[lein-codox "0.9.6"]]
   :codox {:metadata {:doc/format :markdown}}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha16"]
                  [org.clojure/core.cache "0.6.5"]
                  [rill-event-sourcing/rill.event_store "0.2.2"]
                  [rill-event-sourcing/rill.temp_store "0.2.2"]]
   :profiles {:dev
              {:dependencies [[rill-event-sourcing/rill.event_store.mysql "0.2.3-RC2"]
                              [mysql/mysql-connector-java "5.1.6"]]}})
-

--- a/src/rill/wheel.clj
+++ b/src/rill/wheel.clj
@@ -334,7 +334,7 @@
             [rill.message :as message]
             [rill.wheel.repository :as repo]
             [clojure.string :as string]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [rill.wheel.macro-utils :refer [parse-args keyword-in-current-ns parse-pre-post]]))
 
 (defmulti apply-event*

--- a/src/rill/wheel/testing.clj
+++ b/src/rill/wheel/testing.clj
@@ -2,7 +2,7 @@
   "Tools for unit-testing ring.wheel code."
   (:require [rill.event-store.memory :refer [memory-store]]
             [rill.wheel.bare-repository :refer [bare-repository]]
-            [clojure.spec.test :as stest]))
+            [clojure.spec.test.alpha :as stest]))
 
 (defn sub?
   "true if `sub` is either `nil`, equal to `x`, or a recursive
@@ -73,4 +73,3 @@
   (let [instrumented (stest/instrument)]
     (t)
     (stest/unstrument instrumented)))
-


### PR DESCRIPTION
Hello,

Since the latest alpha, the clojure.spec namespace has changed to clojure.spec.alpha. 

This PR reflects this update. 